### PR TITLE
feat:adding get-key-crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ List BugSplat issues with optional filtering. The issues tool lists all crashes 
 Get details of a specific BugSplat issue. The issue tool lists the details of a specific crash and is useful for determining the cause of and fixing a specific crash.
 - `id`: Issue ID to retrieve
 
+### get-key-crashes
+Get all crashes for a specific Stack Key ID (crash group). This tool lists all individual crashes that belong to the same crash group, which is useful for analyzing patterns within a specific type of crash.
+- `stackKeyId`: The Stack Key ID to get crashes for
+- `pageSize`: Number of results per page (1-100, defaults to 10)
+
 ### get-summary
 Get summary of BugSplat issues with optional filtering. The summary tool lists information about groups of crashes and is useful for determining what issues are most prevalent.
 - `applications`: Array of application names to filter by

--- a/spec/key-crash.spec.ts
+++ b/spec/key-crash.spec.ts
@@ -1,0 +1,100 @@
+import { config } from "dotenv";
+import { getKeyCrashes, formatKeyCrashesOutput } from "../src/key-crash.js";
+import { postAndWaitForCrashToProcess } from "./crash.js";
+
+// Load environment variables from .env file
+config();
+
+const database = process.env.BUGSPLAT_DATABASE!;
+const application = "test";
+const version = "1.0.0";
+const description = "Test crash for key crash functionality";
+
+describe("key-crash integration", () => {
+  let crashId: number;
+  let stackKeyId: number;
+
+  beforeAll(async () => {
+    // Create test crash and get its stack key ID
+    const result = await postAndWaitForCrashToProcess(
+      database,
+      application,
+      version,
+      {
+        description,
+      }
+    );
+    crashId = result.crashId;
+    stackKeyId = result.stackKeyId;
+
+    // Create additional crash with same stack key for testing
+    await postAndWaitForCrashToProcess(database, application, version, {
+      description,
+    });
+  });
+
+  describe("getKeyCrashes", () => {
+    it("should fetch crashes for a specific stack key ID", async () => {
+      const crashes = await getKeyCrashes(database, stackKeyId, { pageSize: 10 });
+
+      expect(crashes).toBeDefined();
+      expect(Array.isArray(crashes)).toBe(true);
+      expect(crashes.length).toBeGreaterThan(0);
+
+      // Check that all returned crashes have the same stackKeyId
+      crashes.forEach(crash => {
+        expect(crash.stackKeyId).toBe(stackKeyId);
+      });
+    });
+
+    it("should handle invalid stack key ID", async () => {
+      const nonExistentStackKeyId = 999999;
+      const crashes = await getKeyCrashes(database, nonExistentStackKeyId, { pageSize: 10 });
+
+      expect(crashes).toBeDefined();
+      expect(Array.isArray(crashes)).toBe(true);
+      expect(crashes.length).toBe(0);
+    });
+
+    it("should respect pageSize parameter", async () => {
+      const crashes = await getKeyCrashes(database, stackKeyId, { pageSize: 1 });
+
+      expect(crashes).toBeDefined();
+      expect(crashes.length).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe("formatKeyCrashesOutput", () => {
+    it("should format crash data correctly", async () => {
+      const crashes = await getKeyCrashes(database, stackKeyId, { pageSize: 2 });
+      const output = formatKeyCrashesOutput(crashes, database, stackKeyId);
+
+      expect(typeof output).toBe("string");
+      expect(output).toContain(`Stack Key ID ${stackKeyId}`);
+      expect(output).toContain(database);
+
+      if (crashes.length > 0) {
+        expect(output).toContain("Found");
+        expect(output).toContain("crashes for Stack Key ID");
+      }
+    });
+
+    it("should handle empty results", () => {
+      const output = formatKeyCrashesOutput([], database, 999999);
+
+      expect(typeof output).toBe("string");
+      expect(output).toContain("No crashes found");
+      expect(output).toContain("Stack Key ID 999999");
+      expect(output).toContain(database);
+    });
+
+    it("should format multiple crashes with separators", async () => {
+      const crashes = await getKeyCrashes(database, stackKeyId, { pageSize: 10 });
+      const output = formatKeyCrashesOutput(crashes, database, stackKeyId);
+
+      if (crashes.length > 1) {
+        expect(output).toContain("--------------------------------");
+      }
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { addDefectLink, createDefect, removeDefectLink } from "./defect.js";
 import { resizeImageData } from "./image.js";
 import { formatIssueOutput, getIssue } from "./issue.js";
 import { formatIssuesOutput, listIssues } from "./issues.js";
+import { formatKeyCrashesOutput, getKeyCrashes } from "./key-crash.js";
 import { formatSummaryOutput, getSummary } from "./summary.js";
 import { truncateTextData } from "./text.js";
 
@@ -91,6 +92,34 @@ server.tool(
       checkCredentials();
       const crash = await getIssue(process.env.BUGSPLAT_DATABASE!, id);
       const output = formatIssueOutput(crash, process.env.BUGSPLAT_DATABASE!);
+      return createSuccessResponse(output);
+    } catch (error) {
+      return createErrorResponse(error);
+    }
+  }
+);
+
+server.tool(
+  "get-key-crashes",
+  "Get all crashes for a specific Stack Key ID (crash group). This tool lists all individual crashes that belong to the same crash group, which is useful for analyzing patterns within a specific type of crash.",
+  {
+    stackKeyId: z.number().describe("The Stack Key ID to get crashes for"),
+    pageSize: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .default(10)
+      .describe("Number of results per page (1-100, defaults to 10)"),
+  },
+  async ({ stackKeyId, pageSize }) => {
+    try {
+      checkCredentials();
+      const rows = await getKeyCrashes(process.env.BUGSPLAT_DATABASE!, stackKeyId, {
+        pageSize,
+      });
+
+      const output = formatKeyCrashesOutput(rows, process.env.BUGSPLAT_DATABASE!, stackKeyId);
       return createSuccessResponse(output);
     } catch (error) {
       return createErrorResponse(error);

--- a/src/key-crash.ts
+++ b/src/key-crash.ts
@@ -1,0 +1,70 @@
+import {
+  KeyCrashApiClient,
+  CrashesApiRow,
+} from "@bugsplat/js-api-client";
+import { createBugSplatClient } from "./bugsplat.js";
+
+export async function getKeyCrashes(
+  database: string,
+  stackKeyId: number,
+  options: {
+    pageSize?: number;
+  } = {}
+): Promise<CrashesApiRow[]> {
+  const bugsplat = await createBugSplatClient();
+  const keyCrashClient = new KeyCrashApiClient(bugsplat);
+
+  const response = await keyCrashClient.getCrashes({
+    database,
+    stackKeyId,
+    pageSize: options.pageSize || 10,
+  });
+
+  return response.rows;
+}
+
+export function formatKeyCrashesOutput(
+  rows: CrashesApiRow[],
+  database: string,
+  stackKeyId: number
+): string {
+  if (rows.length === 0) {
+    return `No crashes found for Stack Key ID ${stackKeyId} in database ${database}`;
+  }
+
+  let text = `Found ${rows.length} crashes for Stack Key ID ${stackKeyId} in database ${database}:\n\n`;
+
+  return text + rows
+    .map((row, i) => {
+      let crashText = `Crash #${row.id} on ${row.crashTime}\n`;
+      if (row.appName) {
+        crashText += `Application: ${row.appName}\n`;
+      }
+      if (row.appVersion) {
+        crashText += `Version: ${row.appVersion}\n`;
+      }
+      if (row.userDescription) {
+        crashText += `Description: ${row.userDescription}\n`;
+      }
+      if (row.appDescription) {
+        crashText += `Key: ${row.appDescription}\n`;
+      }
+      if (row.user) {
+        crashText += `User: ${row.user}\n`;
+      }
+      if (row.email) {
+        crashText += `Email: ${row.email}\n`;
+      }
+      if (row.stackKey) {
+        crashText += `Stack Key: ${row.stackKey}\n`;
+      }
+
+      crashText += `Linked Defects: ${row.skDefectLabel || "None"}\n`;
+
+      if (i < rows.length - 1) {
+        crashText += "\n--------------------------------\n\n";
+      }
+      return crashText;
+    })
+    .join("");
+}


### PR DESCRIPTION
Adding the ability to pull crash groups.

Added using [https://app.bugsplat.com/api/keycrash?database={DATABASE}&stackKeyId={GROUP_NUMBER}](https://app.bugsplat.com/api/keycrash?database=%7BDATABASE%7D&stackKeyId=%7BGROUP_NUMBER%7D) api call.